### PR TITLE
[Init] Admin 기능 파일 생성

### DIFF
--- a/src/main/java/com/example/kp3coutsourcingproject/admin/controller/AdminCommentController.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/admin/controller/AdminCommentController.java
@@ -1,0 +1,21 @@
+package com.example.kp3coutsourcingproject.admin.controller;
+
+import com.example.kp3coutsourcingproject.admin.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/kp3c/manage")
+@RequiredArgsConstructor
+public class AdminCommentController {
+    private final AdminService adminService;
+
+    @GetMapping("/comments")
+    public void getComments() { /* 전체 댓글 조회 */ }
+
+    @PutMapping("/comments/{comment_id}")
+    public void updateComment() { /* 댓글 수정 */ }
+
+    @DeleteMapping("/comments/{comment_id}")
+    public void deleteComment() { /* 댓글 삭제 */ }
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/admin/controller/AdminController.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/admin/controller/AdminController.java
@@ -1,0 +1,24 @@
+package com.example.kp3coutsourcingproject.admin.controller;
+
+import com.example.kp3coutsourcingproject.admin.dto.AdminUserResponseDto;
+import com.example.kp3coutsourcingproject.admin.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/kp3c/manage")
+@RequiredArgsConstructor
+public class AdminController {
+
+
+
+    @GetMapping("")
+    public void adminPage() { /* 관리자 페이지 */ }
+
+
+
+
+
+
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/admin/controller/AdminPostController.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/admin/controller/AdminPostController.java
@@ -1,0 +1,30 @@
+package com.example.kp3coutsourcingproject.admin.controller;
+
+import com.example.kp3coutsourcingproject.admin.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/kp3c/manage")
+@RequiredArgsConstructor
+public class AdminPostController {
+    private final AdminService adminService;
+
+    @GetMapping("/posts")
+    public void getPosts() { /* 전체 게시글 조회 */ }
+
+    @PutMapping("/posts/{post_id}")
+    public void updatePost() { /* 게시글 수정 */ }
+
+    @DeleteMapping("/posts/{post_id}")
+    public void deletePost() { /* 게시글 삭제 */ }
+
+    @PostMapping("/notice")
+    public void postNotice() { /* 공지 작성 */ }
+
+    @PutMapping("/notices/{notice_id}")
+    public void updateNotice() { /* 공지 작성 */ }
+
+    @DeleteMapping("/notices/{notice_id}")
+    public void deleteNotice() { /* 공지 삭제 */ }
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/admin/controller/AdminUserController.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/admin/controller/AdminUserController.java
@@ -1,0 +1,30 @@
+package com.example.kp3coutsourcingproject.admin.controller;
+
+import com.example.kp3coutsourcingproject.admin.dto.AdminUserRequestDto;
+import com.example.kp3coutsourcingproject.admin.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/kp3c/manage")
+@RequiredArgsConstructor
+public class AdminUserController {
+    private final AdminService adminService;
+
+    @GetMapping("/users")
+    public void getUsers() { /* 전체 유저 조회 */ }
+
+    @PutMapping("/users/{user_id}")
+    public void updateUserInfo() {
+        /* 회원 정보 수정 */
+    }
+
+    @PutMapping("/users/{user_id}/promote?role={role}")
+    public void promoteUserAdmin() { /* 회원 권한 승격 */ }
+
+    @PutMapping("/users/{user_id}/block")
+    public void blockUser() { /* 회원 차단 */ }
+
+    @DeleteMapping("/users/{user_id}")
+    public void deleteUser() { /* 회원 삭제 */ }
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminApiResponseDto.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminApiResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.kp3coutsourcingproject.admin.dto;
+
+public class AdminApiResponseDto {
+
+    private Integer code;
+    private String msg;
+
+    public AdminApiResponseDto(Integer code, String msg) {
+        this.code = code;
+        this.msg = msg;
+    }
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminCommentRequestDto.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminCommentRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.kp3coutsourcingproject.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminCommentRequestDto {
+    @NotBlank
+    private String content; // 댓글 내용
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminCommentResponseDto.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminCommentResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.kp3coutsourcingproject.admin.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AdminCommentResponseDto {
+    private Long id;
+    private String username;
+    private String nickname;
+    private String content;
+    private String createdAt;
+
+    public AdminCommentResponseDto(Post post) {
+
+        this.id = post.getId();
+        this.username = post.getUsername();
+        this.nickname = post.getNickname();
+
+        this.content = post.getContent();
+
+        this.createdAt = post.getCreatedAt();
+    }
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminPostRequestDto.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminPostRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.kp3coutsourcingproject.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminPostRequestDto {
+    @NotBlank
+    private String content; // 게시글 내용
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminPostResponseDto.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminPostResponseDto.java
@@ -1,0 +1,24 @@
+package com.example.kp3coutsourcingproject.admin.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AdminPostResponseDto {
+
+    private Long id;
+    private String username;
+    private String nickname;
+    private String content;
+    private String createdAt;
+
+    public AdminPostResponseDto(Post post) {
+
+        this.id = post.getId();
+        this.username = post.getUsername();
+        this.nickname = post.getNickname();
+
+        this.content = post.getContent();
+
+        this.createdAt = post.getCreatedAt();
+    }
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminUserRequestDto.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminUserRequestDto.java
@@ -1,0 +1,20 @@
+package com.example.kp3coutsourcingproject.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminUserRequestDto {
+
+    @NotBlank
+    private String username;
+    @NotBlank
+    private String nickname;
+    @NotBlank
+    private String password;
+    private String introduction;
+    @NotBlank
+    private String email;
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminUserResponseDto.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/admin/dto/AdminUserResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.kp3coutsourcingproject.admin.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AdminUserResponseDto {
+
+    private Long id;
+    private String username;
+    private String nickname;
+    private String password;
+    private String introduction;
+    private String email;
+
+    public AdminUserResponseDto(User user) {
+        this.id = user.getId();
+        this.username = user.getUsername();
+        this.nickname = user.getNickname();
+        this.password = user.getPassword();
+        this.introduction = user.getIntroduction();
+        this.introduction = user.getEmail();
+    }
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/admin/entity/Notice.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/admin/entity/Notice.java
@@ -1,0 +1,42 @@
+package com.example.kp3coutsourcingproject.admin.entity;
+
+import com.example.kp3coutsourcingproject.admin.dto.AdminUserRequestDto;
+import jakarta.persistence.*;
+import jdk.jfr.Timestamp;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "notice")
+@NoArgsConstructor
+public class Notice {
+
+    @CreatedDate
+    @Column(updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY) // 회원정보가 필요할 때만 가져올 수 있다
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+
+    public Notice(AdminUserRequestDto requestDto, User user) {
+        this.content = requestDto.getContent();
+        this.user = user;
+    }
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/admin/service/AdminService.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/admin/service/AdminService.java
@@ -1,0 +1,11 @@
+package com.example.kp3coutsourcingproject.admin.service;
+
+import com.example.kp3coutsourcingproject.admin.dto.AdminUserResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+}


### PR DESCRIPTION
## [Init] Admin 기능 파일 생성 
이슈 번호: #8 

## 변경 사항
### 1. Admin 기능 파일 생성
#### controller
> 메서드 수가 많아서 역할마다 컨트롤러를 나누었음<br>
- AdminController → admin 페이지(관리자 페이지) 입구
- AdminUserController → 회원과 관련된 컨트롤러
- AdminPostController  → 게시글 및 공지와 관련된 컨트롤러
- AdminCommentController → 댓글과 관련된 컨트롤러
#### service
- AdminService → 아직 컨트롤러처럼 세분화 시키지 않았음
#### dto
- AdminUserRequestDto
- AdminUserResponseDto
- AdminPostRequestDto
- AdminPostReponseDto
- AdminCommentRequestDto
- AdminCommentResponseDto
- AdminApiResponseDto → `status code`와 `msg` 출력용
#### entity
- Notice → 공지와 관련된 엔티티

### 2. `notice` entity 생성
> 공지를 게시할 때 사용할 엔티티를 생성

![image](https://github.com/JisooPyo/KP3C-backoffice-project/assets/119802267/3abb42e8-b013-4150-a141-4910e29b263b)

post와 중복된 부분이 많아 따로 생성하지 않고 post 엔티티를 그대로 사용할까 했지만, 기능 확장을 염두하여 따로 만들었다.

## Todo List
- 앞으로 해야할 일: 관리자 페이지 제작
- 유저 및 게시글(댓글 포함) 관리는 새로운 브랜치에서 할 예정

## Check List

- [x] ERD 작성
- [x] API 명세 작성
- [X] admin 기능 파일 생성


