### PR TITLE
[Feature] Post 관련 메서드 구현

### DIFF
--- a/src/main/java/com/example/kp3coutsourcingproject/KP3COutsourcingProjectApplication.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/KP3COutsourcingProjectApplication.java
@@ -2,7 +2,9 @@ package com.example.kp3coutsourcingproject;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class KP3COutsourcingProjectApplication {
 

--- a/src/main/java/com/example/kp3coutsourcingproject/common/dto/Timestamped.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/dto/Timestamped.java
@@ -1,0 +1,19 @@
+package com.example.kp3coutsourcingproject.common.dto;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Timestamped {
+	@CreatedDate
+	@Column(updatable = false)
+	@Temporal(TemporalType.TIMESTAMP)
+	private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/post/controller/PostController.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/post/controller/PostController.java
@@ -1,0 +1,72 @@
+package com.example.kp3coutsourcingproject.post.controller;
+
+import com.example.kp3coutsourcingproject.common.dto.ApiResponseDto;
+import com.example.kp3coutsourcingproject.common.security.UserDetailsImpl;
+import com.example.kp3coutsourcingproject.post.dto.PostRequestDto;
+import com.example.kp3coutsourcingproject.post.dto.PostResponseDto;
+import com.example.kp3coutsourcingproject.post.service.PostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/kp3c")
+@RequiredArgsConstructor
+public class PostController {
+	private final PostService postService;
+
+	// 포스트 전체 조회
+	// http://localhost:8080/kp3c/posts
+	@GetMapping("/posts")
+	public ResponseEntity<List<PostResponseDto>> getPosts() {
+		List<PostResponseDto> results = postService.getPosts();
+
+		return ResponseEntity.ok().body(results);
+	}
+
+	// 선택 포스트 조회
+	// http://localhost:8080/kp3c/post/1
+	@GetMapping("/post/{id}")
+	public ResponseEntity<PostResponseDto> getPostById(@PathVariable Long id) {
+		PostResponseDto result = postService.getPostById(id);
+		return ResponseEntity.ok().body(result);
+	}
+
+	// 포스트 작성
+	// http://localhost:8080/kp3c/post
+	@PostMapping("/post")
+	public ResponseEntity<PostResponseDto> createPost(@Valid @RequestBody PostRequestDto requestDto,
+													  @AuthenticationPrincipal UserDetailsImpl userDetails) {
+		PostResponseDto result = postService.createPost(requestDto, userDetails.getUser());
+		// 201 : CREATED
+		return ResponseEntity.status(201).body(result);
+	}
+
+	// 포스트 수정
+	// http://localhost:8080/kp3c/post/1
+	@PutMapping("/post/{id}")
+	public ResponseEntity<PostResponseDto> updatePost(@PathVariable Long id,
+													  @Valid @RequestBody PostRequestDto requestDto,
+													  @AuthenticationPrincipal UserDetailsImpl userDetails) {
+		PostResponseDto result = postService.updatePost(id, requestDto, userDetails.getUser());
+		return ResponseEntity.ok().body(result);
+	}
+
+	// 포스트 삭제
+	// http://localhost:8080/kp3c/post/1
+	@DeleteMapping("/post/{id}")
+	public ResponseEntity<ApiResponseDto> deletePost(@PathVariable Long id,
+													 @AuthenticationPrincipal UserDetailsImpl userDetails) {
+		postService.deletePost(id, userDetails.getUser());
+		return ResponseEntity.ok().body(
+				new ApiResponseDto("게시글 삭제 성공", HttpStatus.OK.value())
+		);
+	}
+
+
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/post/dto/PostRequestDto.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/post/dto/PostRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.kp3coutsourcingproject.post.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class PostRequestDto {
+	@NotNull(message = "내용을 입력하세요.")
+	private String content;
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/post/dto/PostResponseDto.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/post/dto/PostResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.kp3coutsourcingproject.post.dto;
+
+import com.example.kp3coutsourcingproject.common.dto.ApiResponseDto;
+import com.example.kp3coutsourcingproject.post.entity.Post;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PostResponseDto extends ApiResponseDto {
+	private Long id;
+	private String nickname;
+	private String content;
+	private LocalDateTime createdAt;
+
+
+	public PostResponseDto(Post post) {
+		this.id = post.getId();
+		this.nickname = post.getUser().getNickname();
+		this.content = post.getContent();
+		this.createdAt = post.getCreatedAt();
+	}
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/post/entity/Post.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/post/entity/Post.java
@@ -1,0 +1,33 @@
+package com.example.kp3coutsourcingproject.post.entity;
+
+import com.example.kp3coutsourcingproject.common.dto.Timestamped;
+import com.example.kp3coutsourcingproject.post.dto.PostRequestDto;
+import com.example.kp3coutsourcingproject.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Entity
+@Setter
+@Getter
+@Table(name = "posts")
+@NoArgsConstructor
+public class Post extends Timestamped {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "userId")
+	private User user;
+
+	@Column(nullable = false)
+	private String content;
+
+	public Post(PostRequestDto requestDto) {
+		this.content = requestDto.getContent();
+	}
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/post/repository/PostRepository.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/post/repository/PostRepository.java
@@ -1,0 +1,9 @@
+package com.example.kp3coutsourcingproject.post.repository;
+
+import com.example.kp3coutsourcingproject.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post,Long> {
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/post/service/PostService.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/post/service/PostService.java
@@ -1,0 +1,98 @@
+package com.example.kp3coutsourcingproject.post.service;
+
+import com.example.kp3coutsourcingproject.post.dto.PostRequestDto;
+import com.example.kp3coutsourcingproject.post.dto.PostResponseDto;
+import com.example.kp3coutsourcingproject.post.entity.Post;
+import com.example.kp3coutsourcingproject.post.repository.PostRepository;
+import com.example.kp3coutsourcingproject.user.entity.User;
+import com.example.kp3coutsourcingproject.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+	private final PostRepository postRepository;
+	private final UserRepository userRepository;
+
+	// 전체 포스트 조회
+	public List<PostResponseDto> getPosts() {
+		List<PostResponseDto> posts = postRepository.findAll().stream()
+				.map(PostResponseDto::new)
+				.collect(Collectors.toList());
+
+		return posts;
+	}
+
+	// 선택 포스트 조회
+	public PostResponseDto getPostById(Long id) {
+		Post post = findPost(id);
+		return new PostResponseDto(post);
+	}
+
+	// 포스트 작성
+	public PostResponseDto createPost(PostRequestDto requestDto, User user) {
+		User targetUser = findUser(user.getId());
+		Post post = new Post(requestDto);
+		post.setUser(targetUser);
+		postRepository.save(post);
+		return new PostResponseDto(post);
+	}
+
+	// 포스트 수정
+	@Transactional
+	public PostResponseDto updatePost(Long id, PostRequestDto requestDto, User user) {
+		Post post = findPost(id);
+		User targetUser = findUser(user.getId());
+		// 게시글 작성자인지 체크
+		if(isPostAuthor(post,targetUser)){
+			post.setContent(requestDto.getContent());
+			return new PostResponseDto(post);
+		} else {
+			throw new IllegalArgumentException("게시글 작성자만이 게시글을 수정할 수 있습니다.");
+		}
+	}
+
+	// 포스트 삭제
+	public void deletePost(Long id, User user) {
+		Post post = findPost(id);
+		User targetUser = findUser(user.getId());
+		if(isPostAuthor(post,targetUser)){
+			postRepository.deleteById(id);
+		} else {
+			throw new IllegalArgumentException("게시글 작성자만이 게시글을 삭제할 수 있습니다.");
+		}
+	}
+
+	/////////////////////////////////////////////////////////
+
+	// id값으로 post 찾기
+	private Post findPost(long id) {
+		return postRepository.findById(id).orElseThrow(() ->
+				new EntityNotFoundException("존재하지 않는 게시글입니다.")
+		);
+	}
+
+	// id값으로 user 찾기
+	private User findUser(long id) {
+		return userRepository.findById(id).orElseThrow(() ->
+				new EntityNotFoundException("존재하지 않는 유저입니다.")
+		);
+	}
+
+	// 게시글의 작성자가 유저인지 확인
+	private boolean isPostAuthor(Post post, User user){
+		if(post.getUser().getId().equals(user.getId())){
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+
+}


### PR DESCRIPTION
## 관련 Issue : #12 

## 변경 사항

* Post 관련 클래스 추가
* Post CRUD 메서드 구현
* 포스트맨으로 다 체크해보았습니다.

![image](https://github.com/JisooPyo/KP3C-backoffice-project/assets/130378232/b3f27db2-08c5-46a0-88d4-429806564694)

## Todo List

12번 이슈 모두 해결

## Check List

<!-- 기능 구현을 다 했다면? --> 

- [X] 포스트맨으로 체크해 보았나요?
- [X] 다른 팀원의 PR을 보고 코드 리뷰를 남겨 보았나요? 
- [x] PR 수고하셨습니다!! 
- [X] 오늘도 멋있었나요? 당연하지 9조가 제일 멋있9~ 


## 과제에 비해 바뀐 점!

### 1. 

* 과제에서 썼던 코드

```java
postRepository.delete(post);
```

* 바뀐 코드

```java
postRepository.deleteById(id);
```

기존 코드를 id값으로 db에서 찾아서 없애게끔 하였다.

### 2.

* 과제에서 썼던 코드

```java
private Post findPost(long id) {
	return postRepository.findById(id).orElseThrow(() ->
		new IllegalArgumentException("존재하지 않는 게시글입니다.")
        );
}
```

* 바뀐 코드

```java
private Post findPost(long id) {
	return postRepository.findById(id).orElseThrow(() ->
		new EntityNotFoundException("존재하지 않는 게시글입니다.")
        );
}
```

EntityNotFoundException이라는 예외가 있어서 그쪽이 이 메서드에 더 잘 맞는 거 같아서 발생시킬 예외 변경

### 3.

원래 블로그에서는 전체 포스트 조회와 선택한 포스트 조회 메서드를 인증을 받지 않아도 요청할 수 있게끔 해놓고 싶어서

API를 Read하는 부분과 Create, Update, Delete 부분을 다르게 적용시켰는데

(ex. Read 하는 부분은 앞에 /view를 붙여서 /view로 시작되는 메서드는 인증 절차를 거치지 않게 하였다.)
<br><br>
이번 프로젝트에서는 SNS 프로젝트인 만큼, 회원이 아니면 글을 볼 수 없게 해놓아야 해서 API를 비슷하게 다 통일시켰다.

( ex. /posts, /post, /post/{id} )

### 4.

GlobalExceptionHandler가 있으므로 Controller단에서 try-catch를 해주지 않아 조금 더 코드가 간결해졌다.