### PR TITLE
[Refactor] 사용자 팔로우 기능 리팩토링

### DIFF
--- a/src/main/java/com/example/kp3coutsourcingproject/KP3COutsourcingProjectApplication.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/KP3COutsourcingProjectApplication.java
@@ -2,9 +2,7 @@ package com.example.kp3coutsourcingproject;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class KP3COutsourcingProjectApplication {
 

--- a/src/main/java/com/example/kp3coutsourcingproject/config/JpaConfig.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.example.kp3coutsourcingproject.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/config/RestTemplateConfig.java
@@ -2,10 +2,12 @@ package com.example.kp3coutsourcingproject.config;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.Duration;
 
+@Configuration
 public class RestTemplateConfig  {
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {

--- a/src/main/java/com/example/kp3coutsourcingproject/sociallogin/service/KakaoService.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/sociallogin/service/KakaoService.java
@@ -1,6 +1,6 @@
 package com.example.kp3coutsourcingproject.sociallogin.service;
 
-import com.example.kp3coutsourcingproject.jwt.JwtUtil;
+import com.example.kp3coutsourcingproject.common.jwt.JwtUtil;
 import com.example.kp3coutsourcingproject.sociallogin.dto.KakaoUserInfoDto;
 import com.example.kp3coutsourcingproject.user.repository.UserRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -17,8 +18,6 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpHeaders;
 
 @Slf4j(topic = "KAKAO Login")
 @Service

--- a/src/main/java/com/example/kp3coutsourcingproject/user/controller/FollowController.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/controller/FollowController.java
@@ -3,7 +3,7 @@ package com.example.kp3coutsourcingproject.user.controller;
 import com.example.kp3coutsourcingproject.common.dto.ApiResponseDto;
 import com.example.kp3coutsourcingproject.common.security.UserDetailsImpl;
 import com.example.kp3coutsourcingproject.user.dto.FollowResponseDto;
-import com.example.kp3coutsourcingproject.user.dto.ProfileDto;
+import com.example.kp3coutsourcingproject.user.dto.FollowUserDto;
 import com.example.kp3coutsourcingproject.user.service.FollowService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,14 +21,14 @@ public class FollowController {
     private final FollowService followService;
 
     @GetMapping("/users/{username}/followers")
-    public ResponseEntity<List<ProfileDto>> getFollowers(@PathVariable String username) {
-        List<ProfileDto> followers = followService.getFollowers(username);
+    public ResponseEntity<List<FollowUserDto>> getFollowers(@PathVariable String username) {
+        List<FollowUserDto> followers = followService.getFollowers(username);
         return ResponseEntity.ok().body(followers);
     }
 
     @GetMapping("/users/{username}/following")
-    public ResponseEntity<List<ProfileDto>> getFollowing(@PathVariable String username) {
-        List<ProfileDto> following = followService.getFollowing(username);
+    public ResponseEntity<List<FollowUserDto>> getFollowing(@PathVariable String username) {
+        List<FollowUserDto> following = followService.getFollowing(username);
         return ResponseEntity.ok().body(following);
     }
 

--- a/src/main/java/com/example/kp3coutsourcingproject/user/controller/FollowController.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/controller/FollowController.java
@@ -1,0 +1,52 @@
+package com.example.kp3coutsourcingproject.user.controller;
+
+import com.example.kp3coutsourcingproject.common.dto.ApiResponseDto;
+import com.example.kp3coutsourcingproject.common.security.UserDetailsImpl;
+import com.example.kp3coutsourcingproject.user.dto.FollowResponseDto;
+import com.example.kp3coutsourcingproject.user.dto.ProfileDto;
+import com.example.kp3coutsourcingproject.user.service.FollowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/kp3c")
+public class FollowController {
+
+    private final FollowService followService;
+
+    @GetMapping("/users/{username}/followers")
+    public ResponseEntity<List<ProfileDto>> getFollowers(@PathVariable String username) {
+        List<ProfileDto> followers = followService.getFollowers(username);
+        return ResponseEntity.ok().body(followers);
+    }
+
+    @GetMapping("/users/{username}/following")
+    public ResponseEntity<List<ProfileDto>> getFollowing(@PathVariable String username) {
+        List<ProfileDto> following = followService.getFollowing(username);
+        return ResponseEntity.ok().body(following);
+    }
+
+    @PostMapping("/user/follow/{username}")
+    public ResponseEntity<ApiResponseDto> follow(@PathVariable String username, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        followService.follow(username, userDetails.getUser());
+        return ResponseEntity.ok().body(new ApiResponseDto("팔로우 성공", HttpStatus.OK.value()));
+    }
+
+    @PostMapping("/user/unfollow/{username}")
+    public ResponseEntity<ApiResponseDto> unfollow(@PathVariable String username, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        followService.unfollow(username, userDetails.getUser());
+        return ResponseEntity.ok().body(new ApiResponseDto("언팔로우 성공", HttpStatus.OK.value()));
+    }
+
+    @GetMapping("/user/following/{username}")
+    public ResponseEntity<FollowResponseDto> isFollowing(@PathVariable String username, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        boolean isFollowing = followService.isFollowing(username, userDetails.getUser());
+        return ResponseEntity.ok().body(new FollowResponseDto(isFollowing));
+    }
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/user/controller/UserController.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/controller/UserController.java
@@ -2,9 +2,7 @@ package com.example.kp3coutsourcingproject.user.controller;
 
 import com.example.kp3coutsourcingproject.common.dto.ApiResponseDto;
 import com.example.kp3coutsourcingproject.common.jwt.JwtUtil;
-import com.example.kp3coutsourcingproject.common.security.UserDetailsImpl;
 import com.example.kp3coutsourcingproject.sociallogin.service.KakaoService;
-import com.example.kp3coutsourcingproject.user.dto.ProfileDto;
 import com.example.kp3coutsourcingproject.user.dto.SignupRequestDto;
 import com.example.kp3coutsourcingproject.user.service.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -13,9 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
@@ -28,30 +24,30 @@ import java.util.List;
 @RequestMapping("/kp3c/user")
 public class UserController {
 
-    private final UserService userService;
-    private final KakaoService kakaoService;
+	private final UserService userService;
+	private final KakaoService kakaoService;
 
-    @PostMapping("/signup")
-    @ResponseBody
-    public ResponseEntity<ApiResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto, BindingResult bindingResult, HttpServletResponse response) {
-        // Validation 예외처리 - signupRequestDto에서 설정한 글자수, 문자규칙(a~z,A~Z,0~9)에 위배되는 경우 fieldError 리스트에 내용이 추가됨
-        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
-        StringBuilder errorMessage = new StringBuilder();
+	@PostMapping("/signup")
+	@ResponseBody
+	public ResponseEntity<ApiResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto, BindingResult bindingResult, HttpServletResponse response) {
+		// Validation 예외처리 - signupRequestDto에서 설정한 글자수, 문자규칙(a~z,A~Z,0~9)에 위배되는 경우 fieldError 리스트에 내용이 추가됨
+		List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+		StringBuilder errorMessage = new StringBuilder();
 
-        //1건 이상 Validation 관련 에러가 발견된 경우 - 에러메시지(1개~ 여러 개)를 message응답으로 client에 전달
-        if (fieldErrors.size() > 0) {
-            for (FieldError fieldError : bindingResult.getFieldErrors()) {
-                log.error(fieldError.getField() + " 필드 : " + fieldError.getDefaultMessage());
-                errorMessage.append(fieldError.getDefaultMessage()).append("\n ");
-            }
-            response.setStatus(400);
-            return ResponseEntity.status(400).body(new ApiResponseDto(errorMessage.toString(), response.getStatus()));
-        }
+		//1건 이상 Validation 관련 에러가 발견된 경우 - 에러메시지(1개~ 여러 개)를 message응답으로 client에 전달
+		if (fieldErrors.size() > 0) {
+			for (FieldError fieldError : bindingResult.getFieldErrors()) {
+				log.error(fieldError.getField() + " 필드 : " + fieldError.getDefaultMessage());
+				errorMessage.append(fieldError.getDefaultMessage()).append("\n ");
+			}
+			response.setStatus(400);
+			return ResponseEntity.status(400).body(new ApiResponseDto(errorMessage.toString(), response.getStatus()));
+		}
 
-        return ResponseEntity.status(response.getStatus()).body(userService.signup(requestDto, response));
-    }
+		return ResponseEntity.status(response.getStatus()).body(userService.signup(requestDto, response));
+	}
 
-    @GetMapping("/user/kakao/callback")
+    @GetMapping("/kakao/callback")
     public String kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
 
         // code: 카카오 서버로부터 받은 인가코드 service 전달 후 인증처리 및 JWT반환
@@ -63,29 +59,5 @@ public class UserController {
         response.addCookie(cookie);
 
         return "redirect:/";
-    }
-
-    @GetMapping("/{username}/followers")
-    public ResponseEntity<List<ProfileDto>> getFollowers(@PathVariable String username) {
-        List<ProfileDto> followers = userService.getFollowers(username);
-        return ResponseEntity.ok().body(followers);
-    }
-
-    @GetMapping("/{username}/followees")
-    public ResponseEntity<List<ProfileDto>> getFollowees(@PathVariable String username) {
-        List<ProfileDto> followees = userService.getFollowees(username);
-        return ResponseEntity.ok().body(followees);
-    }
-
-    @PostMapping("/follow/{username}")
-    public ResponseEntity<ApiResponseDto> follow(@PathVariable String username, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        userService.follow(username, userDetails.getUser());
-        return ResponseEntity.ok().body(new ApiResponseDto("팔로우 성공", HttpStatus.OK.value()));
-    }
-
-    @PostMapping("/unfollow/{username}")
-    public ResponseEntity<ApiResponseDto> unfollow(@PathVariable String username, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        userService.unfollow(username, userDetails.getUser());
-        return ResponseEntity.ok().body(new ApiResponseDto("언팔로우 성공", HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/com/example/kp3coutsourcingproject/user/controller/UserController.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/controller/UserController.java
@@ -24,28 +24,28 @@ import java.util.List;
 @RequestMapping("/kp3c/user")
 public class UserController {
 
-	private final UserService userService;
-	private final KakaoService kakaoService;
+    private final UserService userService;
+    private final KakaoService kakaoService;
 
-	@PostMapping("/signup")
-	@ResponseBody
-	public ResponseEntity<ApiResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto, BindingResult bindingResult, HttpServletResponse response) {
-		// Validation 예외처리 - signupRequestDto에서 설정한 글자수, 문자규칙(a~z,A~Z,0~9)에 위배되는 경우 fieldError 리스트에 내용이 추가됨
-		List<FieldError> fieldErrors = bindingResult.getFieldErrors();
-		StringBuilder errorMessage = new StringBuilder();
+    @PostMapping("/signup")
+    @ResponseBody
+    public ResponseEntity<ApiResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto, BindingResult bindingResult, HttpServletResponse response) {
+        // Validation 예외처리 - signupRequestDto에서 설정한 글자수, 문자규칙(a~z,A~Z,0~9)에 위배되는 경우 fieldError 리스트에 내용이 추가됨
+        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+        StringBuilder errorMessage = new StringBuilder();
 
-		//1건 이상 Validation 관련 에러가 발견된 경우 - 에러메시지(1개~ 여러 개)를 message응답으로 client에 전달
-		if (fieldErrors.size() > 0) {
-			for (FieldError fieldError : bindingResult.getFieldErrors()) {
-				log.error(fieldError.getField() + " 필드 : " + fieldError.getDefaultMessage());
-				errorMessage.append(fieldError.getDefaultMessage()).append("\n ");
-			}
-			response.setStatus(400);
-			return ResponseEntity.status(400).body(new ApiResponseDto(errorMessage.toString(), response.getStatus()));
-		}
+        //1건 이상 Validation 관련 에러가 발견된 경우 - 에러메시지(1개~ 여러 개)를 message응답으로 client에 전달
+        if (fieldErrors.size() > 0) {
+            for (FieldError fieldError : bindingResult.getFieldErrors()) {
+                log.error(fieldError.getField() + " 필드 : " + fieldError.getDefaultMessage());
+                errorMessage.append(fieldError.getDefaultMessage()).append("\n ");
+            }
+            response.setStatus(400);
+            return ResponseEntity.status(400).body(new ApiResponseDto(errorMessage.toString(), response.getStatus()));
+        }
 
-		return ResponseEntity.status(response.getStatus()).body(userService.signup(requestDto, response));
-	}
+        return ResponseEntity.status(response.getStatus()).body(userService.signup(requestDto, response));
+    }
 
     @GetMapping("/kakao/callback")
     public String kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {

--- a/src/main/java/com/example/kp3coutsourcingproject/user/dto/FollowResponseDto.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/dto/FollowResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.kp3coutsourcingproject.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FollowResponseDto {
+    private boolean isFollowing;
+
+    public FollowResponseDto(boolean isFollowing) {
+        this.isFollowing = isFollowing;
+    }
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/user/dto/FollowUserDto.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/dto/FollowUserDto.java
@@ -6,19 +6,15 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class ProfileDto {
+public class FollowUserDto {
+    private Long id;
     private String username;
     private String nickname;
-    private String introduction;
     private String imageUrl;
-    private int followerCount;
-    private int followingCount;
 
-    public ProfileDto(User user) {
+    public FollowUserDto(User user) {
+        this.id = user.getId();
         this.username = user.getUsername();
         this.nickname = user.getNickname();
-        this.introduction = user.getIntroduction();
-        this.followerCount = user.getFollowList().size();
-        this.followingCount = user.getFollowingList().size();
     }
 }

--- a/src/main/java/com/example/kp3coutsourcingproject/user/repository/FollowRepository.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/repository/FollowRepository.java
@@ -3,9 +3,11 @@ package com.example.kp3coutsourcingproject.user.repository;
 import com.example.kp3coutsourcingproject.user.entity.Follow;
 import com.example.kp3coutsourcingproject.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     boolean existsByFollowerAndFollowee(User follower, User followee);
     Optional<Follow> findByFollowerAndFollowee(User follower, User followee);

--- a/src/main/java/com/example/kp3coutsourcingproject/user/service/FollowService.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/service/FollowService.java
@@ -1,0 +1,71 @@
+package com.example.kp3coutsourcingproject.user.service;
+
+import com.example.kp3coutsourcingproject.user.dto.ProfileDto;
+import com.example.kp3coutsourcingproject.user.entity.Follow;
+import com.example.kp3coutsourcingproject.user.entity.User;
+import com.example.kp3coutsourcingproject.user.repository.FollowRepository;
+import com.example.kp3coutsourcingproject.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FollowService {
+    private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+
+    public List<ProfileDto> getFollowers(String username) {
+        User user = findUser(username);
+        return user.getFollowList()
+                .stream()
+                .map(Follow::getFollower)
+                .map(ProfileDto::new)
+                .toList();
+    }
+
+    public List<ProfileDto> getFollowing(String username) {
+        User user = findUser(username);
+        return user.getFollowingList()
+                .stream()
+                .map(Follow::getFollowee)
+                .map(ProfileDto::new)
+                .toList();
+    }
+
+    public void follow(String username, User user) {
+        User followee = findUser(username);
+        if(followee.getId().equals(user.getId())) {
+            throw new IllegalArgumentException("자기 자신을 팔로우할 수 없습니다.");
+        }
+        if(followRepository.existsByFollowerAndFollowee(user, followee)) {
+            throw new IllegalArgumentException("이미 팔로우한 사용자입니다.");
+        }
+        followRepository.save(new Follow(user, followee));
+    }
+
+    public void unfollow(String username, User user) {
+        User followee = findUser(username);
+        if(followee.getId().equals(user.getId())) {
+            throw new IllegalArgumentException("자기 자신을 언팔로우할 수 없습니다.");
+        }
+        Follow existedFollow = followRepository.findByFollowerAndFollowee(user, followee).orElseThrow(() ->
+                new IllegalArgumentException("팔로우하지 않은 사용자입니다.")
+        );
+        followRepository.delete(existedFollow);
+    }
+
+    public boolean isFollowing(String username, User user) {
+        User followee = findUser(username);
+        return followRepository.existsByFollowerAndFollowee(user, followee);
+    }
+
+    private User findUser(String username) {
+        return userRepository.findByUsername(username).orElseThrow(() ->
+                new IllegalArgumentException("존재하지 않는 사용자입니다.")
+        );
+    }
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/user/service/FollowService.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/service/FollowService.java
@@ -1,6 +1,6 @@
 package com.example.kp3coutsourcingproject.user.service;
 
-import com.example.kp3coutsourcingproject.user.dto.ProfileDto;
+import com.example.kp3coutsourcingproject.user.dto.FollowUserDto;
 import com.example.kp3coutsourcingproject.user.entity.Follow;
 import com.example.kp3coutsourcingproject.user.entity.User;
 import com.example.kp3coutsourcingproject.user.repository.FollowRepository;
@@ -18,21 +18,21 @@ public class FollowService {
     private final UserRepository userRepository;
     private final FollowRepository followRepository;
 
-    public List<ProfileDto> getFollowers(String username) {
+    public List<FollowUserDto> getFollowers(String username) {
         User user = findUser(username);
         return user.getFollowList()
                 .stream()
                 .map(Follow::getFollower)
-                .map(ProfileDto::new)
+                .map(FollowUserDto::new)
                 .toList();
     }
 
-    public List<ProfileDto> getFollowing(String username) {
+    public List<FollowUserDto> getFollowing(String username) {
         User user = findUser(username);
         return user.getFollowingList()
                 .stream()
                 .map(Follow::getFollowee)
-                .map(ProfileDto::new)
+                .map(FollowUserDto::new)
                 .toList();
     }
 

--- a/src/main/java/com/example/kp3coutsourcingproject/user/service/UserService.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/service/UserService.java
@@ -1,32 +1,25 @@
 package com.example.kp3coutsourcingproject.user.service;
 
 import com.example.kp3coutsourcingproject.common.dto.ApiResponseDto;
-import com.example.kp3coutsourcingproject.user.dto.ProfileDto;
 import com.example.kp3coutsourcingproject.user.dto.SignupRequestDto;
-import com.example.kp3coutsourcingproject.user.entity.Follow;
 import com.example.kp3coutsourcingproject.user.entity.User;
 import com.example.kp3coutsourcingproject.user.entity.UserRoleEnum;
-import com.example.kp3coutsourcingproject.user.repository.FollowRepository;
 import com.example.kp3coutsourcingproject.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Optional;
 
 @Service
-@Component
 @RequiredArgsConstructor
 public class UserService {
 
 	private final UserRepository userRepository;
-	private final FollowRepository followRepository;
 	private final PasswordEncoder passwordEncoder;
 
 	// ADMIN_TOKEN
@@ -70,45 +63,5 @@ public class UserService {
 		userRepository.save(user);
 		response.setStatus(200);
 		return new ApiResponseDto("회원가입 완료", response.getStatus());
-	}
-
-	public List<ProfileDto> getFollowers(String username) {
-		User user = findUser(username);
-		return user.getFollowList()
-				.stream()
-				.map(Follow::getFollower)
-				.map(ProfileDto::new)
-				.toList();
-	}
-
-	public List<ProfileDto> getFollowees(String username) {
-		User user = findUser(username);
-		return user.getFollowingList()
-				.stream()
-				.map(Follow::getFollowee)
-				.map(ProfileDto::new)
-				.toList();
-	}
-
-	public void follow(String username, User user) {
-		User follower = findUser(username);
-		if(followRepository.existsByFollowerAndFollowee(follower, user)) {
-			throw new IllegalArgumentException("이미 팔로우한 사용자입니다.");
-		}
-		followRepository.save(new Follow(follower, user));
-	}
-
-	public void unfollow(String username, User user) {
-		User follower = findUser(username);
-		Follow existedFollow = followRepository.findByFollowerAndFollowee(follower, user).orElseThrow(() ->
-			new IllegalArgumentException("팔로우하지 않은 사용자입니다.")
-		);
-		followRepository.delete(existedFollow);
-	}
-
-	private User findUser(String username) {
-		return userRepository.findByUsername(username).orElseThrow(() ->
-				new IllegalArgumentException("존재하지 않는 사용자입니다.")
-		);
 	}
 }

--- a/src/test/java/com/example/kp3coutsourcingproject/service/FollowServiceIntegrationTest.java
+++ b/src/test/java/com/example/kp3coutsourcingproject/service/FollowServiceIntegrationTest.java
@@ -9,7 +9,6 @@ import com.example.kp3coutsourcingproject.user.service.FollowService;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 
 import java.util.List;
 
@@ -19,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT) // 서버의 포트를 랜덤으로 설정
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // 테스트 인스턴스의 생성 단위를 클래스로 변경
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@Rollback(value = false)
 public class FollowServiceIntegrationTest {
     @Autowired
     FollowService followService;
@@ -96,5 +94,18 @@ public class FollowServiceIntegrationTest {
         assertTrue(userBFollowing.isEmpty());
         assertTrue(followService.isFollowing("userC", userA));
         assertFalse(followService.isFollowing("userC", userB));
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("자기 자신을 팔로우 또는 언팔로우 시도하는 경우")
+    void test3() {
+        IllegalArgumentException followException = assertThrows(IllegalArgumentException.class, () ->
+                followService.follow("userA", userA));
+        assertEquals("자기 자신을 팔로우할 수 없습니다.", followException.getMessage());
+
+        IllegalArgumentException unfollowException = assertThrows(IllegalArgumentException.class, () ->
+                followService.unfollow("userB", userB));
+        assertEquals("자기 자신을 언팔로우할 수 없습니다.", unfollowException.getMessage());
     }
 }

--- a/src/test/java/com/example/kp3coutsourcingproject/service/FollowServiceIntegrationTest.java
+++ b/src/test/java/com/example/kp3coutsourcingproject/service/FollowServiceIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.example.kp3coutsourcingproject.service;
 
-import com.example.kp3coutsourcingproject.user.dto.ProfileDto;
+import com.example.kp3coutsourcingproject.user.dto.FollowUserDto;
 import com.example.kp3coutsourcingproject.user.entity.User;
 import com.example.kp3coutsourcingproject.user.entity.UserRoleEnum;
 import com.example.kp3coutsourcingproject.user.repository.FollowRepository;
@@ -52,9 +52,9 @@ public class FollowServiceIntegrationTest {
         followService.follow("userC", userA);
 
         //then
-        List<ProfileDto> userCFollowers = followService.getFollowers("userC");
-        List<ProfileDto> userAFollowing = followService.getFollowing("userA");
-        List<ProfileDto> userCFollowing = followService.getFollowing("userC");
+        List<FollowUserDto> userCFollowers = followService.getFollowers("userC");
+        List<FollowUserDto> userAFollowing = followService.getFollowing("userA");
+        List<FollowUserDto> userCFollowing = followService.getFollowing("userC");
 
         assertThat(userCFollowers)
                 .extracting("username")
@@ -79,9 +79,9 @@ public class FollowServiceIntegrationTest {
         followService.unfollow("userC", userB);
 
         //then
-        List<ProfileDto> userCFollowers = followService.getFollowers("userC");
-        List<ProfileDto> userAFollowing = followService.getFollowing("userA");
-        List<ProfileDto> userBFollowing = followService.getFollowing("userB");
+        List<FollowUserDto> userCFollowers = followService.getFollowers("userC");
+        List<FollowUserDto> userAFollowing = followService.getFollowing("userA");
+        List<FollowUserDto> userBFollowing = followService.getFollowing("userB");
 
         assertThat(userCFollowers)
                 .extracting("username")

--- a/src/test/java/com/example/kp3coutsourcingproject/service/FollowServiceIntegrationTest.java
+++ b/src/test/java/com/example/kp3coutsourcingproject/service/FollowServiceIntegrationTest.java
@@ -30,27 +30,23 @@ public class FollowServiceIntegrationTest {
     @Autowired
     FollowRepository followRepository;
 
-    @Test
-    @Order(1)
-    void test() {
-        //given
-        User userA = new User("userA", "userA", "Abc012#!", "hi", "userA@email.com", UserRoleEnum.USER);
-        User userB = new User("userB", "userB", "Abc012#!", "hi", "userB@email.com", UserRoleEnum.USER);
-        User userC = new User("userC", "userC", "Abc012#!", "hi", "userC@email.com", UserRoleEnum.USER);
+    User userA, userB, userC;
+
+    private void userSetup() {
+        userA = new User("userA", "userA", "Abc012#!", "hi", "userA@email.com", UserRoleEnum.USER);
+        userB = new User("userB", "userB", "Abc012#!", "hi", "userB@email.com", UserRoleEnum.USER);
+        userC = new User("userC", "userC", "Abc012#!", "hi", "userC@email.com", UserRoleEnum.USER);
         userRepository.save(userA);
         userRepository.save(userB);
         userRepository.save(userC);
-        assertEquals(userRepository.findAll().size(), 3);
     }
 
-
     @Test
-    @Order(2)
+    @Order(1)
     @DisplayName("팔로우 이후 팔로워 팔로잉 조회") // A -> B, B -> C, A -> C
     void test1() {
         //given
-        User userA = userRepository.findByUsername("userA").orElse(null);
-        User userB = userRepository.findByUsername("userB").orElse(null);
+        this.userSetup();
 
         //when
         followService.follow("userB", userA);
@@ -61,7 +57,6 @@ public class FollowServiceIntegrationTest {
         List<ProfileDto> userCFollowers = followService.getFollowers("userC");
         List<ProfileDto> userAFollowing = followService.getFollowing("userA");
         List<ProfileDto> userCFollowing = followService.getFollowing("userC");
-        System.out.println("userCFollowers = " + userCFollowers);
 
         assertThat(userCFollowers)
                 .extracting("username")
@@ -79,13 +74,9 @@ public class FollowServiceIntegrationTest {
     }
 
     @Test
-    @Order(3)
+    @Order(2)
     @DisplayName("언팔로우 이후 팔로워 팔로잉 조회") // A -> B, A -> C
     void test2() {
-        //given
-        User userA = userRepository.findByUsername("userA").orElse(null);
-        User userB = userRepository.findByUsername("userB").orElse(null);
-
         //when
         followService.unfollow("userC", userB);
 

--- a/src/test/java/com/example/kp3coutsourcingproject/service/FollowServiceIntegrationTest.java
+++ b/src/test/java/com/example/kp3coutsourcingproject/service/FollowServiceIntegrationTest.java
@@ -1,0 +1,109 @@
+package com.example.kp3coutsourcingproject.service;
+
+import com.example.kp3coutsourcingproject.user.dto.ProfileDto;
+import com.example.kp3coutsourcingproject.user.entity.User;
+import com.example.kp3coutsourcingproject.user.entity.UserRoleEnum;
+import com.example.kp3coutsourcingproject.user.repository.FollowRepository;
+import com.example.kp3coutsourcingproject.user.repository.UserRepository;
+import com.example.kp3coutsourcingproject.user.service.FollowService;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT) // 서버의 포트를 랜덤으로 설정
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) // 테스트 인스턴스의 생성 단위를 클래스로 변경
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Rollback(value = false)
+public class FollowServiceIntegrationTest {
+    @Autowired
+    FollowService followService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    FollowRepository followRepository;
+
+    @Test
+    @Order(1)
+    void test() {
+        //given
+        User userA = new User("userA", "userA", "Abc012#!", "hi", "userA@email.com", UserRoleEnum.USER);
+        User userB = new User("userB", "userB", "Abc012#!", "hi", "userB@email.com", UserRoleEnum.USER);
+        User userC = new User("userC", "userC", "Abc012#!", "hi", "userC@email.com", UserRoleEnum.USER);
+        userRepository.save(userA);
+        userRepository.save(userB);
+        userRepository.save(userC);
+        assertEquals(userRepository.findAll().size(), 3);
+    }
+
+
+    @Test
+    @Order(2)
+    @DisplayName("팔로우 이후 팔로워 팔로잉 조회") // A -> B, B -> C, A -> C
+    void test1() {
+        //given
+        User userA = userRepository.findByUsername("userA").orElse(null);
+        User userB = userRepository.findByUsername("userB").orElse(null);
+
+        //when
+        followService.follow("userB", userA);
+        followService.follow("userC", userB);
+        followService.follow("userC", userA);
+
+        //then
+        List<ProfileDto> userCFollowers = followService.getFollowers("userC");
+        List<ProfileDto> userAFollowing = followService.getFollowing("userA");
+        List<ProfileDto> userCFollowing = followService.getFollowing("userC");
+        System.out.println("userCFollowers = " + userCFollowers);
+
+        assertThat(userCFollowers)
+                .extracting("username")
+                .containsOnly("userA", "userB");
+
+        assertThat(userAFollowing)
+                .extracting("username")
+                .containsOnly("userB", "userC");
+
+        assertTrue(userCFollowing.isEmpty());
+        assertTrue(followService.isFollowing("userB", userA));
+        assertTrue(followService.isFollowing("userC", userB));
+        assertTrue(followService.isFollowing("userC", userA));
+        assertFalse(followService.isFollowing("userA", userB));
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("언팔로우 이후 팔로워 팔로잉 조회") // A -> B, A -> C
+    void test2() {
+        //given
+        User userA = userRepository.findByUsername("userA").orElse(null);
+        User userB = userRepository.findByUsername("userB").orElse(null);
+
+        //when
+        followService.unfollow("userC", userB);
+
+        //then
+        List<ProfileDto> userCFollowers = followService.getFollowers("userC");
+        List<ProfileDto> userAFollowing = followService.getFollowing("userA");
+        List<ProfileDto> userBFollowing = followService.getFollowing("userB");
+
+        assertThat(userCFollowers)
+                .extracting("username")
+                .containsOnly("userA");
+
+        assertThat(userAFollowing)
+                .extracting("username")
+                .containsOnly("userB", "userC");
+
+        assertTrue(userBFollowing.isEmpty());
+        assertTrue(followService.isFollowing("userC", userA));
+        assertFalse(followService.isFollowing("userC", userB));
+    }
+}


### PR DESCRIPTION
## 관련 Issue #41 
**팔로우 기능 api**

- 특정 유저의 팔로워 조회 `/users/{username}/followers`
- 특정 유저의 팔로잉 조회 `/users/{username}/following`
- 팔로우 `/user/follow/{username}`
- 언팔로우 `/user/unfollow/{username}`
- 다른 유저를 팔로우하는지 여부 조회 `/user/following/{username}`

## 변경 사항

* 사용자 팔로우 기능 로직 수정, 리팩토링 및 테스트 코드 작성
1. 기존에 `UserController`, `UserService`에서 작성하던 것을 `FollowController`, `FollowService` 로 분리했습니다.
2. 테스트 코드 실행 오류를 방지하기 위해 JpaAuditing 애너테이션은 `JpaConfig` 파일로 분리했습니다.
3. `ProfileDto`가 사용자 프로필 조회 관련 구현하시는 분들께 혼동을 드리는 것 같아서,
팔로우 기능에서만 사용할 수 있게 `FollowUserDto` 로 클래스 이름을 변경했습니다.
팔로워 또는 팔로우하는 유저의 `id`, `username`, `nickname`, `imageUrl` 을 전달하는 dto입니다.
4. 인증된 유저인 자기자신이 특정 유저를 팔로우하고 있는지 여부를 확인할 수 있는 api 를 추가했습니다.
프론트에서 토글 버튼 구현할 때 호출하면 좋을 것 같습니다.
응답 예시:  `{ isFollowing: true }`


## Todo List
* Security 설정에 대한 고민 - 이렇게 로그인 회원가입 url을 명시적으로 작성해서 허용하는건 어떨까요?

![스크린샷 2023-07-19 오전 10 14 33](https://github.com/JisooPyo/KP3C-backoffice-project/assets/52851594/64ad9745-7d25-4919-bf72-c473f9583353)


## Check List

<!-- 기능 구현을 다 했다면? --> 

- [x] 테스트 케이스 모두 통과하였습니다.

![스크린샷 2023-07-19 오전 9 36 28](https://github.com/JisooPyo/KP3C-backoffice-project/assets/52851594/c3d67d97-a78b-4c48-bac3-9d28147bc7ba)
 
<!-- 기능 구현을 다 못했다면? -->

- [x] 다른 팀원의 PR을 보고 코드 리뷰를 남겨 보았나요? 
- [x] PR 수고하셨습니다!! 
- [X] 오늘도 멋있었나요? 당연하지 9조가 제일 멋있9~ 

## 공유 자료
1. api url 설계 시 참고한 자료입니다.
https://docs.github.com/en/rest/users/followers?apiVersion=2022-11-28

2. 메소드가 길지 않고 메소드명 변수명으로 충분히 설명이 되었다고 생각해서 주석은 따로 추가하지 않았습니다.
클린 코드 관점에서 주석의 역할에 대한 블로그 글 공유드립니다.
https://nesoy.github.io/articles/2018-01/CleanCode-Comment