### PR TITLE
[Feature] 카카오 로그인 및 JWT 토큰 발급

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+## properties ##
+application-db.properties
+application-API-KEY.properties

--- a/src/main/java/com/example/kp3coutsourcingproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/exception/ErrorCode.java
@@ -1,4 +1,16 @@
 package com.example.kp3coutsourcingproject.common.exception;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum ErrorCode {
+    TOKEN_NOT_FOUND(404, "해당 토큰이 존재하지 않습니다."),
+    EXPIRED_ACCESS_TOKEN(404, "액세스 토큰이 만료되어 재발급이 필요합니다."),
+    EXPIRED_REFRESH_TOKEN(404, "리프레시 토큰이 만료되어 로그인이 필요합니다."),
+    INVALID_TOKEN(404, "유효하지 않은 토큰입니다");
+
+    private final int status;
+    private final String message;
 }

--- a/src/main/java/com/example/kp3coutsourcingproject/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/exception/GlobalExceptionHandler.java
@@ -9,12 +9,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice(basePackages = "com.example")
 public class GlobalExceptionHandler {
-
-	// 에러 처리
-	@ExceptionHandler({CustomException.class})
-	private ResponseEntity<ApiResponseDto> handleEnityNotFoundException(EntityNotFoundException ex) {
-		return ResponseEntity.status(HttpStatus.NOT_FOUND)
-				.body(new ApiResponseDto(ex.getMessage(), HttpStatus.NOT_FOUND.value()));
+	@ExceptionHandler(CustomException.class)
+	private ResponseEntity<ApiResponseDto> handleCustomException(CustomException ex) {
+		return ResponseEntity
+				.status(ex.getErrorCode().getStatus())
+				.body(new ApiResponseDto(ex.getMessage(), ex.getErrorCode().getStatus()));
 	}
-
 }

--- a/src/main/java/com/example/kp3coutsourcingproject/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/exception/GlobalExceptionHandler.java
@@ -1,8 +1,6 @@
 package com.example.kp3coutsourcingproject.common.exception;
 
 import com.example.kp3coutsourcingproject.common.dto.ApiResponseDto;
-import jakarta.persistence.EntityNotFoundException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/src/main/java/com/example/kp3coutsourcingproject/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/jwt/JwtAuthenticationFilter.java
@@ -54,7 +54,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 	@Override
 	protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException {
 		User user = ((UserDetailsImpl) authResult.getPrincipal()).getUser();
-		TokenResponse token = jwtUtil.issueToken(user.getEmail(), user.getRole());
+		TokenDto token = jwtUtil.issueToken(user.getEmail(), user.getRole());
 
 		String tokenWithPrefix = JwtUtil.BEARER_PREFIX + token.getAccessToken();
 		response.addHeader(JwtUtil.AUTHORIZATION_HEADER, tokenWithPrefix);

--- a/src/main/java/com/example/kp3coutsourcingproject/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/jwt/JwtAuthenticationFilter.java
@@ -3,7 +3,7 @@ package com.example.kp3coutsourcingproject.common.jwt;
 import com.example.kp3coutsourcingproject.common.dto.ApiResponseDto;
 import com.example.kp3coutsourcingproject.common.security.UserDetailsImpl;
 import com.example.kp3coutsourcingproject.user.dto.LoginRequestDto;
-import com.example.kp3coutsourcingproject.user.entity.UserRoleEnum;
+import com.example.kp3coutsourcingproject.user.entity.User;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
@@ -26,7 +26,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 		this.jwtUtil = jwtUtil;
 		setFilterProcessesUrl("/kp3c/user/login");
 	}
-
 
 	//로그인 시도 시 동작하는 메서드
 	@Override
@@ -54,17 +53,14 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 	// JWT 생성 및 client에 응답
 	@Override
 	protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException {
-		String userId = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
-		UserRoleEnum role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
+		User user = ((UserDetailsImpl) authResult.getPrincipal()).getUser();
+		TokenResponse token = jwtUtil.issueToken(user.getEmail(), user.getRole());
 
-		//사용자 ID/권한으로 JWT 생성
-		String token = jwtUtil.createToken(userId, role);
-		response.addHeader(JwtUtil.AUTHORIZATION_HEADER, token); //헤더에 Authorztion = Bearer {JWT} 추가
+		String tokenWithPrefix = JwtUtil.BEARER_PREFIX + token.getAccessToken();
+		response.addHeader(JwtUtil.AUTHORIZATION_HEADER, tokenWithPrefix);
 
-		//client에 응답하기 "message" = "로그인 성공"/ "status" = "200"
-		ApiResponseDto apiResponseDto = new ApiResponseDto("로그인 성공", response.getStatus());
-		String jsonResponseBody = new ObjectMapper().configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, true).writeValueAsString(apiResponseDto);//한글깨짐문제 방지
-		response.setContentType("application/json"); //contenttype : json방식으로 응답 전달
+		String jsonResponseBody = new ObjectMapper().writeValueAsString(token);
+		response.setContentType("application/json");
 		response.getWriter().write(jsonResponseBody);
 		response.getWriter().flush();
 		response.getWriter().close();
@@ -83,5 +79,4 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 		response.getWriter().flush();
 		response.getWriter().close();
 	}
-
 }

--- a/src/main/java/com/example/kp3coutsourcingproject/common/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/jwt/JwtAuthorizationFilter.java
@@ -59,18 +59,17 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 	}
 
 	// 인증 처리 메서드
-	public void setAuthentication(String username) {
-
+	public void setAuthentication(String email) {
 		SecurityContext context = SecurityContextHolder.createEmptyContext();
-		Authentication authentication = createAuthentication(username);
+		Authentication authentication = createAuthentication(email);
 		context.setAuthentication(authentication);
 
 		SecurityContextHolder.setContext(context);
 	}
 
 	// 인증 객체 생성
-	private Authentication createAuthentication(String username) {
-		UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+	private Authentication createAuthentication(String email) {
+		UserDetails userDetails = userDetailsService.loadUserByUsername(email);
 		return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 	}
 }

--- a/src/main/java/com/example/kp3coutsourcingproject/common/jwt/JwtUtil.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/jwt/JwtUtil.java
@@ -1,5 +1,8 @@
 package com.example.kp3coutsourcingproject.common.jwt;
 
+import com.example.kp3coutsourcingproject.common.exception.CustomException;
+import com.example.kp3coutsourcingproject.common.exception.ErrorCode;
+import com.example.kp3coutsourcingproject.common.redis.RedisUtils;
 import com.example.kp3coutsourcingproject.user.entity.UserRoleEnum;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
@@ -13,20 +16,26 @@ import org.springframework.util.StringUtils;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
+import java.util.Objects;
 
 @Slf4j(topic = "Jwt 관련 로그")
 @Component
 public class JwtUtil {
-
+	private final RedisUtils redisUtils;
 	public static final String AUTHORIZATION_HEADER = "Authorization"; // Header KEY 값
 	public static final String AUTHORIZATION_KEY = "auth"; // 사용자 권한 값의 KEY
 	public static final String BEARER_PREFIX = "Bearer "; // Token 식별자
-	private final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
+	private final long ACCESS_TOKEN_TIME = 1000L * 60 * 30; // 30분
+	private final long REFRESH_TOKEN_TIME = 1000L * 60 * 60 * 24 * 3; // 3일
 
 	@Value("${jwt.secret.key}") // application.properties에 명시되어 있는 secretKey
 	private String secretKey;
 	private Key key; // Decode된 Secret Key를 담는 객체
 	private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256; // 알고리즘
+
+	public JwtUtil(RedisUtils redisUtils) {
+		this.redisUtils = redisUtils;
+	}
 
 	@PostConstruct
 	public void init() {
@@ -34,18 +43,44 @@ public class JwtUtil {
 		key = Keys.hmacShaKeyFor(bytes);
 	}
 
-	// JWT 생성
-	public String createToken(String username, UserRoleEnum role) {
-		Date date = new Date();
+	public TokenResponse issueToken(String email, UserRoleEnum role) {
+		String accessToken = createAccessToken(email, role);
+		String refreshToken = createRefreshToken();
+		redisUtils.put(email, refreshToken, REFRESH_TOKEN_TIME);
+		return new TokenResponse(accessToken, refreshToken);
+	}
 
-		return BEARER_PREFIX +
-				Jwts.builder()
-						.setSubject(username) // 사용자 식별자값(ID)
-						.claim(AUTHORIZATION_KEY, role) // 사용자 권한
-						.setExpiration(new Date(date.getTime() + TOKEN_TIME)) // 만료 시간
-						.setIssuedAt(date) // 발급일
-						.signWith(key, signatureAlgorithm) // 암호화 알고리즘
-						.compact();
+	public TokenResponse reissueToken(String email, UserRoleEnum role) {
+		String refreshToken = redisUtils.get(email, String.class);
+		if(Objects.isNull(refreshToken)) {
+			throw new CustomException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+		}
+		String accessToken = createAccessToken(email, role);
+		return new TokenResponse(accessToken, null);
+	}
+
+	private String createAccessToken(String email, UserRoleEnum role) {
+		Date now = new Date();
+		Date expireDate = new Date(now.getTime() + ACCESS_TOKEN_TIME);
+
+		return Jwts.builder()
+				.setSubject(email)
+				.claim(AUTHORIZATION_KEY, role)
+				.setIssuedAt(now)
+				.setExpiration(expireDate)
+				.signWith(key, signatureAlgorithm)
+				.compact();
+	}
+
+	private String createRefreshToken() {
+		Date now = new Date();
+		Date expireDate = new Date(now.getTime() + REFRESH_TOKEN_TIME);
+
+		return Jwts.builder()
+				.setIssuedAt(now)
+				.setExpiration(expireDate)
+				.signWith(key, signatureAlgorithm)
+				.compact();
 	}
 
 	// header 에서 JWT 가져오기
@@ -62,16 +97,13 @@ public class JwtUtil {
 		try {
 			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
 			return true;
-		} catch (SecurityException | MalformedJwtException | SignatureException e) {
-			log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
-		} catch (ExpiredJwtException e) {
-			log.error("Expired JWT token, 만료된 JWT token 입니다.");
-		} catch (UnsupportedJwtException e) {
-			log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
-		} catch (IllegalArgumentException e) {
-			log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+		} catch(ExpiredJwtException e) {
+			log.error(ErrorCode.EXPIRED_ACCESS_TOKEN.getMessage());
+			throw new CustomException(ErrorCode.EXPIRED_ACCESS_TOKEN);
+		} catch(JwtException e) {
+			log.error(ErrorCode.INVALID_TOKEN.getMessage());
+			throw new CustomException(ErrorCode.INVALID_TOKEN);
 		}
-		return false;
 	}
 
 	// 토큰에서 사용자 정보 가져오기

--- a/src/main/java/com/example/kp3coutsourcingproject/common/jwt/JwtUtil.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/jwt/JwtUtil.java
@@ -45,7 +45,7 @@ public class JwtUtil {
 
 	public TokenResponse issueToken(String email, UserRoleEnum role) {
 		String accessToken = createAccessToken(email, role);
-		String refreshToken = createRefreshToken();
+		String refreshToken = createRefreshToken(email);
 		redisUtils.put(email, refreshToken, REFRESH_TOKEN_TIME);
 		return new TokenResponse(accessToken, refreshToken);
 	}
@@ -72,11 +72,12 @@ public class JwtUtil {
 				.compact();
 	}
 
-	private String createRefreshToken() {
+	private String createRefreshToken(String email) {
 		Date now = new Date();
 		Date expireDate = new Date(now.getTime() + REFRESH_TOKEN_TIME);
 
 		return Jwts.builder()
+				.setSubject(email)
 				.setIssuedAt(now)
 				.setExpiration(expireDate)
 				.signWith(key, signatureAlgorithm)

--- a/src/main/java/com/example/kp3coutsourcingproject/common/jwt/TokenDto.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/jwt/TokenDto.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class TokenResponse {
+public class TokenDto {
     private final String accessToken;
     private final String refreshToken;
 }

--- a/src/main/java/com/example/kp3coutsourcingproject/common/jwt/TokenResponse.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/jwt/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.example.kp3coutsourcingproject.common.jwt;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenResponse {
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/src/main/java/com/example/kp3coutsourcingproject/common/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/security/UserDetailsServiceImpl.java
@@ -15,9 +15,9 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 	private final UserRepository userRepository;
 
 	@Override
-	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-		User user = userRepository.findByUsername(username)
-				.orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
+	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+		User user = userRepository.findByEmail(email)
+				.orElseThrow(() -> new UsernameNotFoundException("Not Found " + email));
 
 		return new UserDetailsImpl(user);
 	}

--- a/src/main/java/com/example/kp3coutsourcingproject/common/security/WebSecurityConfig.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/security/WebSecurityConfig.java
@@ -3,7 +3,6 @@ package com.example.kp3coutsourcingproject.common.security;
 import com.example.kp3coutsourcingproject.common.jwt.JwtAuthenticationFilter;
 import com.example.kp3coutsourcingproject.common.jwt.JwtAuthorizationFilter;
 import com.example.kp3coutsourcingproject.common.jwt.JwtUtil;
-import com.example.kp3coutsourcingproject.user.entity.UserRoleEnum;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -61,7 +60,10 @@ public class WebSecurityConfig {
 		http.authorizeHttpRequests((authorizeHttpRequests) ->
 				authorizeHttpRequests
 						.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
-						.requestMatchers("/kp3c/user/**").permitAll() // '/api/user/'로 시작하는 요청 모두 접근 허가
+						.requestMatchers("/kp3c/user/signup").permitAll()
+						.requestMatchers("/kp3c/user/login").permitAll()
+						.requestMatchers("/kp3c/user/kakao/**").permitAll()
+						.requestMatchers("/kp3c/user/reissue").permitAll()
 						.requestMatchers("/kp3c/manage/**").hasRole("ADMIN") // 관리자="ADMIN"만 /manage 도메인 접근 가능
 						.requestMatchers("/redis/**").permitAll() // redis용 임시 허가
 						// sns는 보통 로그인 안하면 아무것도 못하니까 일단은 요거만 해놓고

--- a/src/main/java/com/example/kp3coutsourcingproject/kakao/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/kakao/dto/KakaoUserInfoDto.java
@@ -1,4 +1,4 @@
-package com.example.kp3coutsourcingproject.sociallogin.dto;
+package com.example.kp3coutsourcingproject.kakao.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/kp3coutsourcingproject/kakao/service/KakaoService.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/kakao/service/KakaoService.java
@@ -1,6 +1,7 @@
 package com.example.kp3coutsourcingproject.kakao.service;
 
 import com.example.kp3coutsourcingproject.common.jwt.JwtUtil;
+import com.example.kp3coutsourcingproject.common.jwt.TokenResponse;
 import com.example.kp3coutsourcingproject.kakao.dto.KakaoUserInfoDto;
 import com.example.kp3coutsourcingproject.user.entity.User;
 import com.example.kp3coutsourcingproject.user.entity.UserRoleEnum;
@@ -37,11 +38,12 @@ public class KakaoService {
     @Value("${kakao-rest-api-key}")
     private String CLIENT_ID;
 
-    public String kakaoLogin(String code) throws JsonProcessingException {
-        String accessToken = getToken(code);
-        KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(accessToken);
+    public TokenResponse kakaoLogin(String code) throws JsonProcessingException {
+        String kakaoToken = getToken(code);
+        KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(kakaoToken);
         User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfo);
-        return jwtUtil.createToken(kakaoUser.getUsername(), kakaoUser.getRole());
+
+        return jwtUtil.issueToken(kakaoUser.getEmail(), kakaoUser.getRole());
     }
 
     private String getToken(String code) throws JsonProcessingException {

--- a/src/main/java/com/example/kp3coutsourcingproject/kakao/service/KakaoService.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/kakao/service/KakaoService.java
@@ -1,7 +1,7 @@
 package com.example.kp3coutsourcingproject.kakao.service;
 
 import com.example.kp3coutsourcingproject.common.jwt.JwtUtil;
-import com.example.kp3coutsourcingproject.common.jwt.TokenResponse;
+import com.example.kp3coutsourcingproject.common.jwt.TokenDto;
 import com.example.kp3coutsourcingproject.kakao.dto.KakaoUserInfoDto;
 import com.example.kp3coutsourcingproject.user.entity.User;
 import com.example.kp3coutsourcingproject.user.entity.UserRoleEnum;
@@ -38,7 +38,7 @@ public class KakaoService {
     @Value("${kakao-rest-api-key}")
     private String CLIENT_ID;
 
-    public TokenResponse kakaoLogin(String code) throws JsonProcessingException {
+    public TokenDto kakaoLogin(String code) throws JsonProcessingException {
         String kakaoToken = getToken(code);
         KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(kakaoToken);
         User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfo);

--- a/src/main/java/com/example/kp3coutsourcingproject/user/controller/UserController.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/controller/UserController.java
@@ -2,7 +2,7 @@ package com.example.kp3coutsourcingproject.user.controller;
 
 import com.example.kp3coutsourcingproject.common.dto.ApiResponseDto;
 import com.example.kp3coutsourcingproject.common.jwt.JwtUtil;
-import com.example.kp3coutsourcingproject.sociallogin.service.KakaoService;
+import com.example.kp3coutsourcingproject.kakao.service.KakaoService;
 import com.example.kp3coutsourcingproject.user.dto.SignupRequestDto;
 import com.example.kp3coutsourcingproject.user.service.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -49,11 +49,7 @@ public class UserController {
 
     @GetMapping("/kakao/callback")
     public String kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
-
-        // code: 카카오 서버로부터 받은 인가코드 service 전달 후 인증처리 및 JWT반환
         String token = kakaoService.kakaoLogin(code);
-
-        // cookie 생성 및 직접 브라우저에 set
         Cookie cookie = new Cookie(JwtUtil.AUTHORIZATION_HEADER, token.substring(7));
         cookie.setPath("/");
         response.addCookie(cookie);

--- a/src/main/java/com/example/kp3coutsourcingproject/user/entity/User.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/entity/User.java
@@ -15,80 +15,67 @@ import java.util.List;
 @Table(name = "users")
 @NoArgsConstructor
 public class User {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@Column(unique = true)
-	private String username;
+    @Column(unique = true)
+    private String username;
 
-	// nickname이 null로 들어오면 username과 같은 값을 넣도록 하고 싶음.
-	@Column(nullable = false)
-	private String nickname;
+    // nickname이 null로 들어오면 username과 같은 값을 넣도록 하고 싶음.
+    @Column(nullable = false)
+    private String nickname;
 
-	@Column(nullable = false)
-	private String password;
+    @Column(nullable = false)
+    private String password;
 
-	// nullable = false 설정을 안해주면 어떻게 되지? 소개 안 쓰고 싶은 사람도 있는데!
-	private String introduction;
+    // nullable = false 설정을 안해주면 어떻게 되지? 소개 안 쓰고 싶은 사람도 있는데!
+    private String introduction;
 
-	@Column(nullable = false)
-	private String email;
+    @Column(nullable = false)
+    private String email;
 
-	@Column(nullable = false)
-	@Enumerated(value = EnumType.STRING)
-	private UserRoleEnum role;
-	
-	private Long kakaoId;
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private UserRoleEnum role;
 
-	@OneToMany(mappedBy = "followee", cascade = CascadeType.ALL)
-	private List<Follow> followList = new ArrayList<>();
+    private Long kakaoId;
 
-	@OneToMany(mappedBy = "follower", cascade = CascadeType.ALL)
-	private List<Follow> followingList = new ArrayList<>();
+    @OneToMany(mappedBy = "followee", cascade = CascadeType.ALL)
+    private List<Follow> followList = new ArrayList<>();
 
-	@Column(nullable = false)
-	private String imageFile;
+    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL)
+    private List<Follow> followingList = new ArrayList<>();
 
-	public User(String username, String nickname, String password, String introduction, String email, UserRoleEnum role, String image) {
-		this.username = username;
-		this.nickname = nickname;
-		this.password = password;
-		this.introduction = introduction;
-		this.email = email;
-		this.role = role;
-		this.imageFile = image;
-	}
+    @Column(nullable = false)
+    private String imageFile;
 
-	public void update(ProfileRequestDto requestDto) {
-		this.nickname = requestDto.getNickname();
-		this.introduction = requestDto.getIntroduction();
-		// this.imageUrl = requestDto.getImageUrl();
-	}
+    public User(String username, String nickname, String password, String introduction, String email, UserRoleEnum role, String image) {
+        this.username = username;
+        this.nickname = nickname;
+        this.password = password;
+        this.introduction = introduction;
+        this.email = email;
+        this.role = role;
+        this.imageFile = image;
+    }
 
-	public User(String nickname, String password, String email, UserRoleEnum role, Long kakaoId) {
-		this.nickname = nickname;
-		this.password = password;
-		this.email = email;
-		this.role = role;
-		this.kakaoId = kakaoId;
-	}
+    public void update(ProfileRequestDto requestDto) {
+        this.nickname = requestDto.getNickname();
+        this.introduction = requestDto.getIntroduction();
+        // this.imageUrl = requestDto.getImageUrl();
+    }
 
-	public User updateKakaoId(Long kakaoId) {
-		this.kakaoId = kakaoId;
-		return this;
-	}
+    public User(String nickname, String password, String email, UserRoleEnum role, Long kakaoId) {
+        this.nickname = nickname;
+        this.password = password;
+        this.email = email;
+        this.role = role;
+        this.kakaoId = kakaoId;
+    }
 
-	public User(String nickname, String password, String email, UserRoleEnum role, Long kakaoId) {
-		this.nickname = nickname;
-		this.password = password;
-		this.email = email;
-		this.role = role;
-		this.kakaoId = kakaoId;
-	}
-
-	public User updateKakaoId(Long kakaoId) {
-		this.kakaoId = kakaoId;
-		return this;
-	}
+    public User updateKakaoId(Long kakaoId) {
+        this.kakaoId = kakaoId;
+        return this;
+    }
 }

--- a/src/main/java/com/example/kp3coutsourcingproject/user/entity/User.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/entity/User.java
@@ -18,7 +18,7 @@ public class User {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false, unique = true)
+	@Column(unique = true)
 	private String username;
 
 	// nickname이 null로 들어오면 username과 같은 값을 넣도록 하고 싶음.
@@ -29,7 +29,6 @@ public class User {
 	private String password;
 
 	// nullable = false 설정을 안해주면 어떻게 되지? 소개 안 쓰고 싶은 사람도 있는데!
-	@Column(nullable = false)
 	private String introduction;
 
 	@Column(nullable = false)
@@ -38,6 +37,8 @@ public class User {
 	@Column(nullable = false)
 	@Enumerated(value = EnumType.STRING)
 	private UserRoleEnum role;
+	
+	private Long kakaoId;
 
 	@OneToMany(mappedBy = "followee", cascade = CascadeType.ALL)
 	private List<Follow> followList = new ArrayList<>();
@@ -52,5 +53,18 @@ public class User {
 		this.introduction = introduction;
 		this.email = email;
 		this.role = role;
+	}
+
+	public User(String nickname, String password, String email, UserRoleEnum role, Long kakaoId) {
+		this.nickname = nickname;
+		this.password = password;
+		this.email = email;
+		this.role = role;
+		this.kakaoId = kakaoId;
+	}
+
+	public User updateKakaoId(Long kakaoId) {
+		this.kakaoId = kakaoId;
+		return this;
 	}
 }

--- a/src/main/java/com/example/kp3coutsourcingproject/user/entity/User.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/entity/User.java
@@ -19,7 +19,7 @@ public class User {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false, unique = true)
+	@Column(unique = true)
 	private String username;
 
 	// nickname이 null로 들어오면 username과 같은 값을 넣도록 하고 싶음.
@@ -30,7 +30,6 @@ public class User {
 	private String password;
 
 	// nullable = false 설정을 안해주면 어떻게 되지? 소개 안 쓰고 싶은 사람도 있는데!
-	@Column(nullable = false)
 	private String introduction;
 
 	@Column(nullable = false)
@@ -39,6 +38,8 @@ public class User {
 	@Column(nullable = false)
 	@Enumerated(value = EnumType.STRING)
 	private UserRoleEnum role;
+	
+	private Long kakaoId;
 
 	@OneToMany(mappedBy = "followee", cascade = CascadeType.ALL)
 	private List<Follow> followList = new ArrayList<>();
@@ -63,5 +64,18 @@ public class User {
 		this.nickname = requestDto.getNickname();
 		this.introduction = requestDto.getIntroduction();
 		// this.imageUrl = requestDto.getImageUrl();
+	}
+
+	public User(String nickname, String password, String email, UserRoleEnum role, Long kakaoId) {
+		this.nickname = nickname;
+		this.password = password;
+		this.email = email;
+		this.role = role;
+		this.kakaoId = kakaoId;
+	}
+
+	public User updateKakaoId(Long kakaoId) {
+		this.kakaoId = kakaoId;
+		return this;
 	}
 }

--- a/src/main/java/com/example/kp3coutsourcingproject/user/repository/UserRepository.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/repository/UserRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User,Long> {
-	Optional<User> findByUsername(String username);
-	Optional<User> findByEmail(String email);
+    Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
+    Optional<User> findByKakaoId(Long kakaoId);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,3 @@
-spring.datasource.url="db??"
-spring.datasource.username=root
-spring.datasource.password="????"
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update
@@ -10,3 +7,5 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
 
 jwt.secret.key=7Iqk7YyM66W07YOA7L2U65Sp7YG065+9U3ByaW5n6rCV7J2Y7Yqc7YSw7LWc7JuQ67mI7J6F64uI64ukLg==
+
+spring.profiles.include=db,API-KEY


### PR DESCRIPTION
## 관련 Issue #4 #28 #44 

## 변경 사항

* 카카오 로그인 구현
  - `https://kauth.kakao.com/oauth/authorize?client_id={REST_API_KEY}&
  redirect_uri=http://localhost:8080/kp3c/user/kakao/callback&response_type=code`
  - 로그인 성공 시 accessToken 과 refreshToken 발급
  - 발급된 refreshToken 을 Redis에 저장  ->  email 과 refreshToken 을 `key-value` 로 함

* 토큰 재발급 구현
   - `GET /kp3c/user/reissue` 
  - 만료 시 Redis에 refreshToken 이 존재하는지 확인 후 재발급
* 로그아웃 구현
  - `DELETE /kp3c/user/logout` 
  - 로그아웃 시 accessToken 을 Redis blacklist 에 등록

### 제안
기존 `application.properties` 에서 팀원마다 다른 설정을 파일로 분리해보았습니다.

![스크린샷 2023-07-22 오전 12 46 07](https://github.com/JisooPyo/KP3C-backoffice-project/assets/52851594/cb73cad9-66cf-4224-9ca8-6525ad36187f)


### Test

브라우저로 카카오 소셜 로그인 테스트 완료했습니다.
![스크린샷 2023-07-21 오후 7 47 10](https://github.com/JisooPyo/KP3C-backoffice-project/assets/52851594/a7723018-7954-4d0f-823d-1bf9ab19bf79)

`redis-cli`를 통해 Redis에 토큰이 잘 저장됨을 확인하였습니다.
![스크린샷 2023-07-21 오후 7 47 38](https://github.com/JisooPyo/KP3C-backoffice-project/assets/52851594/502765fd-367b-452f-94ae-6985f276a8b1)
accessToken 만료되었을 때 재발급하는 api 테스트 완료했습니다.
(refreshToken은 `null` 반환을 의도하였습니다.)
![스크린샷 2023-07-21 오후 8 53 29](https://github.com/JisooPyo/KP3C-backoffice-project/assets/52851594/bf7a3aea-287c-496d-924d-7a8d30efbc6f)
Redis 블랙리스트를 사용한 로그아웃 api 테스트 완료했습니다.
![스크린샷 2023-07-22 오전 12 38 03](https://github.com/JisooPyo/KP3C-backoffice-project/assets/52851594/2e0edd24-7ae0-45c5-8fb5-34c360e4cede)


## Check List

- [x] 포스트맨으로 체크해 보았나요?
- [x] 다른 팀원의 PR을 보고 코드 리뷰를 남겨 보았나요? 
- [x] PR 수고하셨습니다!! 
- [X] 오늘도 멋있었나요? 당연하지 9조가 제일 멋있9~ 

## 참고 자료
https://inf.run/Lw5g
https://wnwngus.tistory.com/65?category=894390


