### PR TITLE
[Feature] Username과 Email 두 가지로 로그인하기

### DIFF
--- a/src/main/java/com/example/kp3coutsourcingproject/common/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/common/security/UserDetailsServiceImpl.java
@@ -15,9 +15,9 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 	private final UserRepository userRepository;
 
 	@Override
-	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-		User user = userRepository.findByEmail(email)
-				.orElseThrow(() -> new UsernameNotFoundException("Not Found " + email));
+	public UserDetails loadUserByUsername(String usernameOrEmail) throws UsernameNotFoundException {
+		User user = userRepository.findByUsernameOrEmail(usernameOrEmail, usernameOrEmail)
+				.orElseThrow(() -> new UsernameNotFoundException("Not Found " + usernameOrEmail));
 
 		return new UserDetailsImpl(user);
 	}

--- a/src/main/java/com/example/kp3coutsourcingproject/user/repository/UserRepository.java
+++ b/src/main/java/com/example/kp3coutsourcingproject/user/repository/UserRepository.java
@@ -10,5 +10,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User,Long> {
     Optional<User> findByUsername(String username);
     Optional<User> findByEmail(String email);
+    Optional<User> findByUsernameOrEmail(String username, String email);
     Optional<User> findByKakaoId(Long kakaoId);
 }


### PR DESCRIPTION
## 관련 Issue #62 
https://github.com/JisooPyo/KP3C-backoffice-project/issues/62

## 변경 사항
#### UserRepository.java
> findByUsernameOrEmail 메서드 추가
```java
Optional<User> findByUsernameOrEmail(String username, String email);
```
#### UserDetailsServiceImpl.java
> findByUser() → findByUserOrEmail()
```java
@Override
public UserDetails loadUserByUsername(String usernameOrEmail) throws UsernameNotFoundException {
    User user = userRepository.findByUsernameOrEmail(usernameOrEmail, usernameOrEmail)
                .orElseThrow(() -> new UsernameNotFoundException("Not Found " + usernameOrEmail));
    return new UserDetailsImpl(user);
}
```

### Postman 테스트 결과
![login_email](https://github.com/JisooPyo/KP3C-backoffice-project/assets/119802267/4181555d-cced-469f-a99c-55a07e45e484) ![login_username](https://github.com/JisooPyo/KP3C-backoffice-project/assets/119802267/3fe0cae7-7ee6-49c8-b43e-d26e9f04611f)
